### PR TITLE
Search images regardless of capitalization

### DIFF
--- a/vcl_client/vcl.py
+++ b/vcl_client/vcl.py
@@ -83,7 +83,8 @@ def images(search, refresh):
         to_print = json.loads(cached_image_list)
 
     if search:
-        to_print = [image for image in to_print if search in image['Name']]
+        to_print = [image for image in to_print
+                    if search.lower() in image['Name'].lower()]
 
     click.echo(tabulate.tabulate(to_print, headers='keys'))
 


### PR DESCRIPTION
Convert both the search query and the image name to lowercase before
comparing to ignore capitalization while searching for an image.
