### PR TITLE
Add endpoint URL to config

### DIFF
--- a/tests/test_vcl.py
+++ b/tests/test_vcl.py
@@ -4,7 +4,6 @@ import mock
 from click import testing
 
 from vcl_client import vcl
-
 from vcl_client import cfg
 from tests import fakes
 
@@ -32,19 +31,24 @@ class TestAuthCheck(unittest.TestCase):
 
         vcl.auth_check()
 
-        mock_echo.assert_called_with('Credentials not found. Run `vcl login`.')
+        mock_echo.assert_called_with('Credentials not found. Run `vcl config`.')
         mock_sys.assert_called_with(1)
 
 
-class TestLogin(unittest.TestCase):
+class TestConfig(unittest.TestCase):
     @mock.patch('keyring.set_password')
     @mock.patch('vcl_client.cfg.write_conf')
-    def test_login(self, mock_write_conf, mock_set_pass):
+    def test_config(self, mock_write_conf, mock_set_pass):
         runner = testing.CliRunner()
-        runner.invoke(vcl.login,
-                      input='%s\n%s\n' % (fakes.USERNAME, fakes.PASSWORD))
+        inputs = (fakes.USERNAME, fakes.PASSWORD, fakes.ENDPOINT)
+        runner.invoke(vcl.config, input='%s\n%s\n%s\n' % inputs)
 
-        mock_write_conf.assert_called_with(cfg.USERNAME_KEY, fakes.USERNAME)
+        calls = [
+            mock.call(cfg.USERNAME_KEY, fakes.USERNAME, write=False),
+            mock.call(cfg.ENDPOINT_KEY, fakes.ENDPOINT)
+        ]
+
+        mock_write_conf.assert_has_calls(calls)
         mock_set_pass.assert_called_with('system', fakes.USERNAME,
                                          fakes.PASSWORD)
 

--- a/vcl_client/cfg.py
+++ b/vcl_client/cfg.py
@@ -9,7 +9,7 @@ CONFIG_FILE_PATH = os.path.expanduser('~/.vcl.conf')
 CONF_SECTION = 'vcl'
 
 DEFAULT_ENDPOINT = 'https://vcl.ncsu.edu/scheduling/index.php?mode=xmlrpccall'
-BASE_URL_KEY = 'xmlrpc_base_url'
+ENDPOINT_KEY = 'xmlrpc_base_url'
 IMAGE_LIST_KEY = 'image_list'
 USERNAME_KEY = 'username'
 
@@ -21,7 +21,6 @@ def initialize_config():
     """Sets the initial config file options."""
     if not CONF.has_section(CONF_SECTION):
         CONF.add_section(CONF_SECTION)
-        write_conf(BASE_URL_KEY, DEFAULT_ENDPOINT)
 
 
 def get_conf(key):
@@ -32,13 +31,14 @@ def get_conf(key):
         return None
 
 
-def write_conf(key, data):
+def write_conf(key, data, write=True):
     """Writes key:data to the config file."""
-    config_file = open(CONFIG_FILE_PATH, 'w')
-
     CONF.set(CONF_SECTION, key, data)
-    CONF.write(config_file)
-    config_file.close()
+
+    if write:
+        config_file = open(CONFIG_FILE_PATH, 'w')
+        CONF.write(config_file)
+        config_file.close()
 
 
 def get_password():

--- a/vcl_client/request.py
+++ b/vcl_client/request.py
@@ -12,7 +12,7 @@ REQUEST_LIST_ENDPOINT = 'XMLRPCgetRequestIds'
 
 def call_api(endpoint, params):
     """Calls the API."""
-    base_url = cfg.get_conf(cfg.BASE_URL_KEY)
+    base_url = cfg.get_conf(cfg.ENDPOINT_KEY)
     username = cfg.get_conf(cfg.USERNAME_KEY)
     data = xmlrpclib.dumps(params, endpoint)
     headers = {

--- a/vcl_client/vcl.py
+++ b/vcl_client/vcl.py
@@ -16,7 +16,7 @@ def auth_check():
     username = cfg.get_conf(cfg.USERNAME_KEY)
     password = cfg.get_password()
     if not username or not password:
-        click.echo('Credentials not found. Run `vcl login`.')
+        click.echo('Credentials not found. Run `vcl config`.')
         sys.exit(1)
 
 
@@ -59,15 +59,18 @@ def ssh():
 @vcl.command()
 @click.option('--username', prompt=True)
 @click.option('--password', prompt=True, hide_input=True)
-def login(username, password):
+@click.option('--endpoint', prompt=True, default=cfg.DEFAULT_ENDPOINT)
+def config(username, password, endpoint):
     """Stores username in conf file and password in memory."""
-    cfg.write_conf(cfg.USERNAME_KEY, username)
+    cfg.write_conf(cfg.USERNAME_KEY, username, write=False)
     keyring.set_password('system', username, password)
+    cfg.write_conf(cfg.ENDPOINT_KEY, endpoint)
 
 
 @vcl.command(name='list')
 def request_list():
     """Lists the currently running requests."""
+    auth_check()
     requests = request.request_list()
 
     if requests:


### PR DESCRIPTION
The XMLRPC endpoint should be configurable from the CLI, so adding
the option to configure it to the initial setup. Because of the new
option, the `login` option has now been changed to `config`.

Closes #10
