### PR TITLE
Fix image filtering

### DIFF
--- a/vcl_client/vcl.py
+++ b/vcl_client/vcl.py
@@ -98,7 +98,7 @@ def delete():
 
 
 @vcl.command()
-@click.option('--filter',
+@click.option('filter_term', '--filter',
               default=None,
               help='Filters by name of image.')
 @click.option('--refresh',


### PR DESCRIPTION
The `filter` option on `vcl images` wasn't named properly in the
method. Adding an option to make sure it it recognized and doesn't
shadow the built-in Python name `filter`.
