### PR TITLE
Validate credentials during configuration

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+import unittest
+
+import mock
+
+from vcl_client import cfg
+from vcl_client import utils
+from tests import fakes
+
+class TestAuthCheck(unittest.TestCase):
+    @mock.patch('vcl_client.cfg.get_password')
+    @mock.patch('vcl_client.cfg.get_conf')
+    def test_auth_check(self, mock_get_conf, mock_get_password):
+        mock_get_conf.return_value = fakes.USERNAME
+        mock_get_password.return_value = fakes.PASSWORD
+
+        utils.auth_check()
+
+        mock_get_conf.assert_called_with(cfg.USERNAME_KEY)
+        mock_get_password.assert_called()
+
+    @mock.patch('sys.exit')
+    @mock.patch('click.echo')
+    @mock.patch('vcl_client.cfg.get_password')
+    @mock.patch('vcl_client.cfg.get_conf')
+    def test_auth_check_no_creds(self, mock_get_conf, mock_get_password,
+                                 mock_echo, mock_sys):
+        mock_get_conf.return_value = None
+        mock_get_password.return_value = None
+
+        utils.auth_check()
+
+        mock_echo.assert_called_with('Credentials not found. Run `vcl config`.')
+        mock_sys.assert_called_with(1)

--- a/tests/test_vcl.py
+++ b/tests/test_vcl.py
@@ -8,47 +8,22 @@ from vcl_client import cfg
 from tests import fakes
 
 
-class TestAuthCheck(unittest.TestCase):
-    @mock.patch('vcl_client.cfg.get_password')
-    @mock.patch('vcl_client.cfg.get_conf')
-    def test_auth_check(self, mock_get_conf, mock_get_password):
-        mock_get_conf.return_value = fakes.USERNAME
-        mock_get_password.return_value = fakes.PASSWORD
-
-        vcl.auth_check()
-
-        mock_get_conf.assert_called_with(cfg.USERNAME_KEY)
-        mock_get_password.assert_called()
-
-    @mock.patch('sys.exit')
-    @mock.patch('click.echo')
-    @mock.patch('vcl_client.cfg.get_password')
-    @mock.patch('vcl_client.cfg.get_conf')
-    def test_auth_check_no_creds(self, mock_get_conf, mock_get_password,
-                                 mock_echo, mock_sys):
-        mock_get_conf.return_value = None
-        mock_get_password.return_value = None
-
-        vcl.auth_check()
-
-        mock_echo.assert_called_with('Credentials not found. Run `vcl config`.')
-        mock_sys.assert_called_with(1)
-
-
 class TestConfig(unittest.TestCase):
     @mock.patch('keyring.set_password')
-    @mock.patch('vcl_client.cfg.write_conf')
-    def test_config(self, mock_write_conf, mock_set_pass):
+    @mock.patch('vcl_client.cfg.set_conf')
+    @mock.patch('vcl_client.request.validate_credentials')
+    def test_config(self, mock_valid, mock_set_conf, mock_set_pass):
         runner = testing.CliRunner()
         inputs = (fakes.USERNAME, fakes.PASSWORD, fakes.ENDPOINT)
         runner.invoke(vcl.config, input='%s\n%s\n%s\n' % inputs)
 
         calls = [
-            mock.call(cfg.USERNAME_KEY, fakes.USERNAME, write=False),
+            mock.call(cfg.USERNAME_KEY, fakes.USERNAME),
             mock.call(cfg.ENDPOINT_KEY, fakes.ENDPOINT)
         ]
 
-        mock_write_conf.assert_has_calls(calls)
+        mock_valid.assert_called()
+        mock_set_conf.assert_has_calls(calls)
         mock_set_pass.assert_called_with('system', fakes.USERNAME,
                                          fakes.PASSWORD)
 
@@ -56,7 +31,7 @@ class TestConfig(unittest.TestCase):
 class TestImages(unittest.TestCase):
     @mock.patch('click.echo')
     @mock.patch('vcl_client.cfg.get_conf')
-    @mock.patch('vcl_client.vcl.auth_check')
+    @mock.patch('vcl_client.utils.auth_check')
     def test_images(self, mock_auth, mock_get_conf, mock_echo):
         mock_get_conf.return_value = fakes.JSON_RETURN
 

--- a/vcl_client/cfg.py
+++ b/vcl_client/cfg.py
@@ -31,14 +31,19 @@ def get_conf(key):
         return None
 
 
-def write_conf(key, data, write=True):
+def set_conf(key, data, write=False):
     """Writes key:data to the config file."""
     CONF.set(CONF_SECTION, key, data)
 
     if write:
-        config_file = open(CONFIG_FILE_PATH, 'w')
-        CONF.write(config_file)
-        config_file.close()
+        write_conf()
+
+
+def write_conf():
+    """Writes configuration changes to the filesystem."""
+    config_file = open(CONFIG_FILE_PATH, 'w')
+    CONF.write(config_file)
+    config_file.close()
 
 
 def get_password():

--- a/vcl_client/request.py
+++ b/vcl_client/request.py
@@ -8,6 +8,7 @@ from vcl_client import cfg
 BOOT_ENDPOINT = 'XMLRPCaddRequest'
 IMAGES_ENDPOINT = 'XMLRPCgetImages'
 REQUEST_LIST_ENDPOINT = 'XMLRPCgetRequestIds'
+TEST_ENDPOINT = 'XMLRPCtest'
 
 
 def call_api(endpoint, params):
@@ -48,3 +49,17 @@ def request_list():
     """Calls the API and returns a list of requests."""
     response = call_api(REQUEST_LIST_ENDPOINT, ())
     return response[0][0]['requests']
+
+
+def validate_credentials():
+    """Calls a test API method to validate credentials."""
+    try:
+        response = call_api(TEST_ENDPOINT, ())
+        status = response[0][0]['status']
+
+        if status != 'success':
+            raise ValueError
+    except (xmlrpclib.Fault, ValueError):
+        raise ValueError('Endpoint did not accept credentials.')
+    except:
+        raise ValueError('Credentials or endpoint invalid.')

--- a/vcl_client/utils.py
+++ b/vcl_client/utils.py
@@ -1,0 +1,16 @@
+"""Helper functions for the rest of the client."""
+
+import sys
+
+import click
+
+from vcl_client import cfg
+
+
+def auth_check():
+    """On authenticated calls, checks is user/pass exist."""
+    username = cfg.get_conf(cfg.USERNAME_KEY)
+    password = cfg.get_password()
+    if not username or not password:
+        click.echo('Credentials not found. Run `vcl config`.')
+        sys.exit(1)


### PR DESCRIPTION
The VCL XMLRPC offers a test endpoint to ensure that authentication
works correctly. Now when a user configures for the first time, their
credentials (and by extension their endpoint) are validated before they
are written to the config file.

Closes #13
