### PR TITLE
Make image argument more flexible

### DIFF
--- a/vcl_client/request.py
+++ b/vcl_client/request.py
@@ -1,6 +1,7 @@
 """Handles the XMLRPC server communication"""
 
 import urllib2
+import json
 import xmlrpclib
 
 from vcl_client import cfg
@@ -39,10 +40,30 @@ def boot(params):
                            % (status, response))
 
 
-def images():
+def images(filter_term=None, refresh=False):
     """Calls the API and returns a list of images."""
-    response = call_api(IMAGES_ENDPOINT, ())
-    return response[0][0]
+    cached_image_list = cfg.get_conf(cfg.IMAGE_LIST_KEY)
+
+    if refresh or not cached_image_list:
+        response = call_api(IMAGES_ENDPOINT, ())
+        all_image_data = response[0][0]
+        all_images = [[i['id'], i['name']] for i in all_image_data]
+
+        # Caching response for subsequent queries
+        cfg.set_conf(cfg.IMAGE_LIST_KEY, json.dumps(all_images), write=True)
+    else:
+        all_images = json.loads(cached_image_list)
+
+    if filter_term:
+        filtered_images = [image for image in all_images
+                           if filter_term.lower() in image[1].lower()]
+
+        if not filtered_images:
+            raise ValueError('No matches found for that filter.')
+
+        return filtered_images
+
+    return all_images
 
 
 def request_list():

--- a/vcl_client/utils.py
+++ b/vcl_client/utils.py
@@ -14,3 +14,11 @@ def auth_check():
     if not username or not password:
         click.echo('Credentials not found. Run `vcl config`.')
         sys.exit(1)
+
+def is_number(string):
+    """Returns true if a string can be successfully cast into a number."""
+    try:
+        float(string)
+        return True
+    except ValueError:
+        return False


### PR DESCRIPTION
When requesting a VM, you shouldn't have to memorize the image ID.
It's not possible to use all or part of the image's name when
starting a request. If there are multiple results for the search
term, a list of possible images is displayed and the user is asked
to clarify which image they want to start.

Closes #7
