### PR TITLE
Generate params in api, not cli

### DIFF
--- a/vcl_client/api.py
+++ b/vcl_client/api.py
@@ -46,8 +46,9 @@ def call_api(endpoint, params):
     return xmlrpclib.loads(raw_xml)
 
 
-def request(params):
+def request(image_id, start, length, timeout):
     """Calls the API and throws an error if request isn't successful."""
+    params = (image_id, start, length, timeout)
     response = call_api(REQUEST_ENDPOINT, params)
     status = response[0][0]['status']
 

--- a/vcl_client/cli.py
+++ b/vcl_client/cli.py
@@ -26,9 +26,10 @@ def vcl():
 def request_instance(image, start, length, timeout):
     """Creates a new request for virtual computing resources."""
     image_id = utils.get_image_id(image)
-    params = (image_id, start, length, 0 if timeout else 1)
+    timeout = 0 if timeout else 1
+
     try:
-        api.request(params)
+        api.request(image_id, start, length, timeout)
     except RuntimeError as error:
         click.echo("ERROR: %s" % error.message)
 


### PR DESCRIPTION
`request` created the params in cli.py instead of passing the arguments
to api.py. This isn't optimal, so changing that.
