### PR TITLE
Implement Extend

### DIFF
--- a/vcl_client/api.py
+++ b/vcl_client/api.py
@@ -15,6 +15,7 @@ REQUEST_LENGTH = 480
 REQUEST_ADD = 'XMLRPCaddRequest'
 REQUEST_CONNECTION = 'XMLRPCgetRequestConnectData'
 REQUEST_DELETE = 'XMLRPCendRequest'
+REQUEST_EXTEND = 'XMLRPCextendRequest'
 REQUEST_STATUS = 'XMLRPCgetRequestStatus'
 IMAGES_ENDPOINT = 'XMLRPCgetImages'
 REQUEST_LIST_ENDPOINT = 'XMLRPCgetRequestIds'
@@ -58,6 +59,15 @@ def delete(request_id):
     """Calls the API to delete requests."""
     params = (request_id,)
     response = call_api(REQUEST_DELETE, params)
+    status = response['status']
+
+    if status != 'success':
+        raise RuntimeError("%s." % response['errormsg'])
+
+def extend(request_id, extend_time):
+    """Calls the API to delete requests."""
+    params = (request_id, extend_time)
+    response = call_api(REQUEST_EXTEND, params)
     status = response['status']
 
     if status != 'success':

--- a/vcl_client/cli.py
+++ b/vcl_client/cli.py
@@ -111,10 +111,20 @@ def delete(request_id):
     except RuntimeError as error:
         utils.handle_error(error.message)
 
-
-def extend():
+@vcl.command()
+@click.argument('extend_time')
+@click.option('--request-id',
+              help='ID of the request to connect to.')
+def extend(extend_time, request_id):
     """Extends the reservation time on a request."""
-    pass
+    if not request_id:
+        request_id = utils.choose_active_request()
+
+    try:
+        api.extend(request_id, extend_time)
+        click.echo("Request %s extended successfully." % request_id)
+    except RuntimeError as error:
+        utils.handle_error(error.message)
 
 
 @vcl.command()


### PR DESCRIPTION
`vcl extend [minutes]` extends a request given a request ID and
a number of minutes. If a request ID is not given explicitly, the
user is prompted with a list of active requests that they can extend.
The extend_time is in terms of minutes, which VCL will round up to
the nearest 15 minutes.
